### PR TITLE
Fix: remove js for hardened browsers

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -133,7 +133,6 @@ ul {
 
 .shell-block {
 	animation: 2s blink step-end infinite;
-	color: ;	
 }
 
 @keyframes blink {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 						<a class="logo-styling" href="https://www.reddit.com/user/jhx0"><i class="account-logo fa-brands fa-reddit"></i></a>
 						<a class="logo-styling" href="https://fosstodon.org/@jhx"><i class="account-logo fa-brands fa-mastodon"></i></a>
 						<p id="email-txt">..or via eMail:</p>
-						<a id="email" class="logo-styling" href="#"><i class="account-logo fa-solid fa-envelope"></i></a>
+						<a id="email" class="logo-styling" href="mailto:jhx0x00@gmail.com"><i class="account-logo fa-solid fa-envelope"></i></a>
 					</div>
 					<div class="right-content">
 						<div class="main-text">
@@ -55,9 +55,5 @@
 				</main>
 			</div>
 		</div>
-		<script>
-			var link = document.getElementById('email');
-			link.href = "ma" + "il" + "to" + ":" + "jhx" + "0x00" + "@" + "gm" + "ail" + ".com";
-		</script>
 	</body>
 </html>


### PR DESCRIPTION
Several browsers, such as Tor browser, and Icecat, disable JS code on websites through the NoScript addon. So hovering or clicking on the e-mail logo will show the current site instead. Removing JS code will fix it.